### PR TITLE
Update main.py `import progressbar2` changed to `import progressbar`

### DIFF
--- a/youtube_upload/main.py
+++ b/youtube_upload/main.py
@@ -35,7 +35,7 @@ from . import playlists
 
 # http://code.google.com/p/python-progressbar (>= 2.3)
 try:
-    import progressbar2
+    import progressbar
 except ImportError:
     progressbar = None
 


### PR DESCRIPTION
Changed `import progressbar2` to `import progressbar`.  Even the progressbar2 is installed as pip install progressbar2 it is imported as progressbar.  Otherwise the progressbar is not seen.  